### PR TITLE
バグ取り。（main.exe)

### DIFF
--- a/Assets/Prefabs/Online/OnlinePlayer_Tanuki.prefab
+++ b/Assets/Prefabs/Online/OnlinePlayer_Tanuki.prefab
@@ -1802,7 +1802,7 @@ MonoBehaviour:
   m_PrefabParentObject: {fileID: 0}
   m_PrefabInternal: {fileID: 100100000}
   m_GameObject: {fileID: 1553408173420364}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: ac2f2c3f538195f46b65210a9c7ceb86, type: 3}
   m_Name: 

--- a/Assets/Scripts/C#/Controller/PunipuniSource/PunipuniController.cs
+++ b/Assets/Scripts/C#/Controller/PunipuniSource/PunipuniController.cs
@@ -278,7 +278,6 @@ public class PunipuniController : MonoBehaviour
             tapeffect.EffectFlug = true;                                  // エフェクト更新フラグON
             tapeffect.SetEffectType(EFFECT_TYPE.HOLD);                    // エフェクトタイプセット
 
-            Debug.Log("ホールドエフェクト発生");
         }
 
         //----------------------------------------------------------------------

--- a/Assets/Scripts/C#/Network/PlayerNetworkSetup.cs
+++ b/Assets/Scripts/C#/Network/PlayerNetworkSetup.cs
@@ -13,14 +13,17 @@ public class PlayerNetworkSetup : NetworkBehaviour
     // Use this for initialization
     void Start()
 	{
-		//ローディングイメージのアクティブを切る
-		GameObject.Find("OnlineCanvas/LoadingImage").SetActive(false);
+		//ローディングイメージのアクティブを切るサーバーと自分で2回入ってきたんだが
+		//GameObject.Find("OnlineCanvas/LoadingImage").SetActive(false);
 
 		//自分が操作するオブジェクトに限定する
 		if (isLocalPlayer)
 		{
-			//PlayerCameraを使うため、Scene Cameraを非アクティブ化
-			GameObject.Find("Scene Camera").SetActive(false);
+            //ローディングイメージのアクティブを切る
+            GameObject.Find("OnlineCanvas/LoadingImage").SetActive(false);
+
+            //PlayerCameraを使うため、Scene Cameraを非アクティブ化
+            GameObject.Find("Scene Camera").SetActive(false);
 
 			//Camera,AudioListenerの各コンポーネントをアクティブ化
 			PlayerCamera.GetComponent<Camera>().enabled = true;
@@ -28,7 +31,11 @@ public class PlayerNetworkSetup : NetworkBehaviour
 
 			//LocalPlayerのAnimatorパラメータを自動的に送る
 			GetComponent<NetworkAnimator>().SetParameterAutoSend(0, true);
-		}
+
+            //カメラの取得等があるため、ここでPostureControllerのスクリプトをOnにしてStartメソッド呼び出し。
+            GetComponent<PostureController>().enabled = true;
+
+        }
 		else
 		{
 			//自分以外の移動スクリプトを切る

--- a/Assets/Scripts/C#/Player/PostureController.cs
+++ b/Assets/Scripts/C#/Player/PostureController.cs
@@ -35,7 +35,7 @@ public class PostureController : NetworkBehaviour
     void Start()
     {
 		gameObject.transform.localPosition = new Vector3(0.0f, 25.0f, 0.0f);
-		GameObject.Find("OnlineCanvas/LodingImage").SetActive(false);
+		//GameObject.Find("OnlineCanvas/LodingImage").SetActive(false);     なにこれ1
         // アニメーション情報の取得
         animator = GetComponent<Animator>();
 

--- a/Assets/Sprites.meta
+++ b/Assets/Sprites.meta
@@ -1,0 +1,9 @@
+fileFormatVersion: 2
+guid: 0ce04c94c1770404f819805188ca2b1b
+folderAsset: yes
+timeCreated: 1507786421
+licenseType: Free
+DefaultImporter:
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/EditorBuildSettings.asset
+++ b/ProjectSettings/EditorBuildSettings.asset
@@ -8,10 +8,10 @@ EditorBuildSettings:
   - enabled: 0
     path: Assets/Scenes/Title.unity
     guid: 4a2d9ea51bcd2a640b2ded2ac9f84292
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Home.unity
     guid: 5b39b6739e446274c973fc917ac201d0
-  - enabled: 1
+  - enabled: 0
     path: Assets/Scenes/Offline.unity
     guid: 68ca8cde34f5365448041ee0ad8cfd9a
   - enabled: 1

--- a/ProjectSettings/GraphicsSettings.asset
+++ b/ProjectSettings/GraphicsSettings.asset
@@ -36,7 +36,6 @@ GraphicsSettings:
   - {fileID: 10753, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 10770, guid: 0000000000000000f000000000000000, type: 0}
   - {fileID: 16000, guid: 0000000000000000f000000000000000, type: 0}
-  - {fileID: 16002, guid: 0000000000000000f000000000000000, type: 0}
   m_PreloadedShaders: []
   m_SpritesDefaultMaterial: {fileID: 10754, guid: 0000000000000000f000000000000000,
     type: 0}


### PR DESCRIPTION
プレイヤーの後にカメラ等が生成されるため、プレイヤー内でカメラ等を最初に取得するとカメラが取得出来なくなったりする。
そのため、PostureControllerをNetworkPlayer内でonにし、制御することで後からカメラを取得する事にする。

現在、カメラの回転が移動に反映されないバグアリ。